### PR TITLE
Don't prepend internal section links

### DIFF
--- a/include-files.lua
+++ b/include-files.lua
@@ -36,7 +36,7 @@ local function update_contents(blocks, shift_by, include_path)
     end,
     -- If link paths are relative then prepend include file path
     Link = function (link)
-        if path.is_relative(link.target) then
+        if path.is_relative(link.target) and string.sub(path.filename(link.target), 1, 1) ~= '#' then
             link.target = path.normalize(path.join({include_path, link.target}))
         end
         return link


### PR DESCRIPTION
A small change to check if the "filename" of a path is just a heading link, in which case we don't want to prepend it as this breaks section linking.

This fixes an issue I've been having where section linking is broken when linking to a section in the overall document from an included file, as the included file's links are all prepended with it's subdir.