### PR TITLE
Add `include-as-code-block` logic

### DIFF
--- a/expected-auto.native
+++ b/expected-auto.native
@@ -164,6 +164,13 @@
 , CodeBlock
     ( "" , [ "c" ] , [ ( "include" , "subdir/somecode.c" ) ] )
     ""
+, Header
+    1
+    ( "include-code" , [] , [] )
+    [ Str "Include" , Space , Str "Code" ]
+, CodeBlock
+    ( "" , [ "org" ] , [] )
+    "* Org header\n\nThis is /emphasized/.\n"
 , Header 1 ( "appendix" , [] , [] ) [ Str "Appendix" ]
 , Para
     [ Str "More"

--- a/expected.native
+++ b/expected.native
@@ -164,6 +164,13 @@
 , CodeBlock
     ( "" , [ "c" ] , [ ( "include" , "subdir/somecode.c" ) ] )
     ""
+, Header
+    1
+    ( "include-code" , [] , [] )
+    [ Str "Include" , Space , Str "Code" ]
+, CodeBlock
+    ( "" , [ "org" ] , [] )
+    "* Org header\n\nThis is /emphasized/.\n"
 , Header 1 ( "appendix" , [] , [] ) [ Str "Appendix" ]
 , Para
     [ Str "More"

--- a/include-files.lua
+++ b/include-files.lua
@@ -6,13 +6,14 @@
 -- Module pandoc.path is required and was added in version 2.12
 PANDOC_VERSION:must_be_at_least '2.12'
 
+local pandoc = require 'pandoc'
 local List = require 'pandoc.List'
 local path = require 'pandoc.path'
 local system = require 'pandoc.system'
 
 --- Get include auto mode
 local include_auto = false
-function get_vars (meta)
+local function get_vars (meta)
   if meta['include-auto'] then
     include_auto = true
   end
@@ -20,7 +21,7 @@ end
 
 --- Keep last heading level found
 local last_heading_level = 0
-function update_last_level(header)
+local function update_last_level(header)
   last_heading_level = header.level
 end
 
@@ -62,8 +63,7 @@ local function update_contents(blocks, shift_by, include_path)
 end
 
 --- Filter function for code blocks
-local transclude
-function transclude (cb)
+local function transclude (cb)
   -- ignore code blocks which are not of class "include".
   if not cb.classes:includes 'include' then
     return

--- a/include-files.lua
+++ b/include-files.lua
@@ -62,6 +62,32 @@ local function update_contents(blocks, shift_by, include_path)
   return pandoc.walk_block(pandoc.Div(blocks), update_contents_filter).content
 end
 
+--- Include given file paths as code-blocks
+--- while keeping the remaining attributes.
+local function include_as_code_block(cb)
+  local _, match_pos = cb.classes:find('include-as-code-block')
+  if match_pos == nil then
+    return
+  end
+
+  cb.classes:remove(match_pos)
+  local paths = cb.text
+
+  cb.text = ""
+  for line in paths:gmatch('[^\n]+') do
+    if line:sub(1,2) ~= '//' then
+      local fh = io.open(line)
+      if not fh then
+        io.stderr:write("Cannot open file " .. line .. " | Skipping include-as-code-block\n")
+      else
+        cb.text = cb.text .. fh:read "*a"
+        fh:close()
+      end
+    end
+  end
+  return cb
+end
+
 --- Filter function for code blocks
 local function transclude (cb)
   -- ignore code blocks which are not of class "include".
@@ -123,5 +149,6 @@ end
 
 return {
   { Meta = get_vars },
-  { Header = update_last_level, CodeBlock = transclude }
+  { Header = update_last_level, CodeBlock = transclude },
+  { CodeBlock = include_as_code_block }
 }

--- a/sample.md
+++ b/sample.md
@@ -37,6 +37,13 @@ file-f.md
 subdir/file-g.md
 ```
 
+# Include Code
+
+``` {.include-as-code-block .org}
+// include org-mode file as code-block
+file-d.org
+```
+
 # Appendix
 
 More info goes here.


### PR DESCRIPTION
Hey, 

first, thanks for creating and maintaining this filter!
For a personal project, I sometimes also need to include the contents of source code files into the final document as a "raw" code-block.
(For example, this project's `README.md` could include the source code of the `sample.md` file.)

As this filter already handles _includes_ I thought it might be nice to add the `include-as-code-block` feature to this filter as well, avoiding having to include two files for "fairly" similar features. (Although internally `include-as-code-block` is quite a bit simpler.)

I understand that this might not be the exact goal of this filter, so feel free to close this PR if you feel like it does not belong to it.

PS: Happy to update the documentation and maybe clean up the code a bit if you would consider it relevant for the upstream repository.